### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/components/Dashboard/DashboardView.tsx
+++ b/src/components/Dashboard/DashboardView.tsx
@@ -46,22 +46,22 @@ export function DashboardView({
   return (
     <div className="p-6 space-y-8">
       {/* En-tête */}
-      <div className="flex items-center justify-between">
-        <div className="text-center flex-1">
+      <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+        <div className="text-center md:text-left flex-1">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">Tableau de Bord Familial</h1>
           <p className="text-gray-600">Planning partagé et conseils nutritionnels pour toute la famille</p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex flex-col md:flex-row gap-3 w-full md:w-auto">
           <button
             onClick={() => setShowFoodManagement(true)}
-            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105"
+            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 w-full md:w-auto"
           >
             <Settings className="w-5 h-5" />
             Gérer les aliments
           </button>
           <button
             onClick={() => setShowAddFoodModal(true)}
-            className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors flex items-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105"
+            className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors flex items-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 w-full md:w-auto"
           >
             <Plus className="w-5 h-5" />
             Créer un aliment

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Users, Calendar, BarChart3, ShoppingCart } from 'lucide-react';
+import React, { useState } from 'react';
+import { Users, Calendar, BarChart3, ShoppingCart, Menu } from 'lucide-react';
 
 interface HeaderProps {
   activeTab: string;
@@ -8,6 +8,8 @@ interface HeaderProps {
 }
 
 export function Header({ activeTab, onTabChange, profileCount }: HeaderProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   const tabs = [
     { id: 'dashboard', label: 'Tableau de bord', icon: BarChart3 },
     { id: 'profile', label: 'Profil', icon: Users },
@@ -16,7 +18,7 @@ export function Header({ activeTab, onTabChange, profileCount }: HeaderProps) {
 
   return (
     <header className="bg-gradient-to-r from-green-500 to-blue-600 text-white shadow-lg">
-      <div className="container mx-auto px-4 py-4">
+      <div className="container mx-auto px-4 sm:px-6 py-4">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <div className="w-8 h-8 bg-orange-400 rounded-full flex items-center justify-center">
@@ -24,19 +26,33 @@ export function Header({ activeTab, onTabChange, profileCount }: HeaderProps) {
             </div>
             NutriFamily
           </h1>
-          <div className="flex items-center gap-2 bg-white/20 px-3 py-1 rounded-full">
-            <Users className="w-4 h-4" />
-            <span className="text-sm font-medium">{profileCount} profil{profileCount > 1 ? 's' : ''}</span>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 bg-white/20 px-3 py-1 rounded-full">
+              <Users className="w-4 h-4" />
+              <span className="text-sm font-medium">{profileCount} profil{profileCount > 1 ? 's' : ''}</span>
+            </div>
+            <button
+              onClick={() => setIsMenuOpen(o => !o)}
+              className="p-2 rounded-md bg-white/20 hover:bg-white/30 md:hidden"
+              aria-label="Ouvrir le menu"
+            >
+              <Menu className="w-5 h-5" />
+            </button>
           </div>
         </div>
-        
-        <nav className="flex gap-2 overflow-x-auto">
+
+        <nav
+          className={`${isMenuOpen ? 'flex' : 'hidden'} flex-col gap-2 overflow-x-auto md:flex md:flex-row`}
+        >
           {tabs.map(tab => {
             const Icon = tab.icon;
             return (
               <button
                 key={tab.id}
-                onClick={() => onTabChange(tab.id)}
+                onClick={() => {
+                  onTabChange(tab.id);
+                  setIsMenuOpen(false);
+                }}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg whitespace-nowrap transition-colors ${
                   activeTab === tab.id
                     ? 'bg-white/20 text-white font-semibold'


### PR DESCRIPTION
## Summary
- add mobile hamburger menu to main header
- make dashboard header buttons stack on small screens

## Testing
- `npm run lint` *(fails: 'nutrients' is assigned a value but never used, 'error' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bcc48b908333a84d169c1f3ece84