### PR TITLE
feat: validate Supabase env variables

### DIFF
--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,8 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
-import type { Food } from '../types';
+import type { Food, NutrientData } from '../types';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    'VITE_SUPABASE_URL et VITE_SUPABASE_ANON_KEY doivent être définis dans .env'
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
@@ -126,7 +132,7 @@ export function getSportsNutritionSuggestions(deficiency: string): string[] {
 export async function addCustomFood(foodData: {
   name: string;
   category?: string;
-  nutritionalValues: any;
+  nutritionalValues: NutrientData;
 }): Promise<boolean> {
   try {
     // Générer un ID numérique unique pour l'aliment (bigint compatible)


### PR DESCRIPTION
## Summary
- ensure Supabase env vars are present before creating client
- type custom food nutritional values to avoid `any`

## Testing
- `npm run lint` *(fails: unused vars and other lint errors in unrelated files)*
- `npx eslint src/utils/supabaseClient.ts`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68c6c72bc05c83338bd589dc692d12fe